### PR TITLE
Feat: Add "sensai" page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND noninteractive
 ENV LC_CTYPE=C.UTF-8
 
+RUN chmod 1777 /tmp
 RUN sed -i.bak 's|https\?://archive.ubuntu.com|http://mirrors.hust.edu.cn|g' /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN apt-get update && \
         htop
 
 RUN export DOWNLOAD_URL="https://mirrors.tuna.tsinghua.edu.cn/docker-ce" && curl -fsSL https://get.docker.com | /bin/sh
+RUN mkdir -p /etc/docker
 RUN echo '{ "data-root": "/opt/pwn.college/data/docker" }' > /etc/docker/daemon.json
 
 RUN docker buildx install
-
 RUN git clone --branch 3.6.0 https://github.com/CTFd/CTFd /opt/CTFd
 
 RUN wget -O /etc/docker/seccomp.json https://gitee.com/mirrors/moby/raw/master/profiles/seccomp/default.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
 
   open-webui:
     container_name: open-webui
-    image: cees3/sensai:v2.31
+    image: cees3/sensai:v2.36
     environment:
       - OLLAMA_BASE_URLS=http://222.20.126.129:11434
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,13 +185,31 @@ services:
       - acme:/etc/acme.sh
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
+  open-webui:
+    container_name: open-webui
+    image: cees3/sensai:v2.31
+    environment:
+      - OLLAMA_BASE_URLS=http://222.20.126.129:11434
+    volumes:
+      - open-webui:/app/backend/data
+    networks:
+      user_network:
+        aliases:
+          - sensai
+        ipv4_address: 10.114.0.2
+    restart: always
+    depends_on:
+      - nginx
+
+
 volumes:
   conf:
   html:
   dhparam:
   certs:
   acme:
-
+  open-webui:
+  
 networks:
   user_network:
     name: user_network

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -90,3 +90,5 @@ for host in $(cat $DOJO_DIR/user_firewall.allowed); do
 done
 iptables -I DOCKER-USER -i user_network -s 10.114.0.0/24 -m conntrack --ctstate NEW -j ACCEPT
 iptables -I DOCKER-USER -i user_network -d 10.114.0.0/16 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+iptables -I DOCKER-USER -i user_network -s 10.114.0.2 -j ACCEPT
+iptables -I DOCKER-USER -o user_network -d 10.114.0.2 -j ACCEPT

--- a/dojo_plugin/__init__.py
+++ b/dojo_plugin/__init__.py
@@ -31,6 +31,7 @@ from .pages.writeups import writeups
 from .pages.belts import belts
 from .pages.index import static_html_override
 from .pages.kook import kook
+from .pages.sensai import sensai
 from .api import api
 
 
@@ -137,6 +138,7 @@ def load(app):
     app.register_blueprint(belts)
     app.register_blueprint(kook)
     app.register_blueprint(api, url_prefix="/pwncollege_api/v1")
+    app.register_blueprint(sensai)
 
     app.jinja_env.filters["markdown"] = render_markdown
 

--- a/dojo_plugin/pages/sensai.py
+++ b/dojo_plugin/pages/sensai.py
@@ -1,0 +1,33 @@
+from urllib.parse import quote
+
+from flask import request, Blueprint, render_template
+from CTFd.utils.user import get_current_user, is_admin
+from CTFd.utils.decorators import authed_only, admins_only
+from CTFd.plugins import bypass_csrf_protection
+
+from ..utils import redirect_internal
+from ..utils.dojo import get_current_dojo_challenge
+
+
+sensai = Blueprint("pwncollege_sensai", __name__)
+
+
+@sensai.route("/sensai")
+@authed_only
+def view_sensai():
+    active = bool(get_current_dojo_challenge())
+    return render_template("iframe.html", iframe_name="sensai", iframe_src="/sensai/", active=active)
+
+
+@sensai.route("/sensai/", methods=["GET", "POST"])
+@sensai.route("/sensai/<path:path>", methods=["GET", "POST"])
+@sensai.route("/sensai/", websocket=True)
+@sensai.route("/sensai/<path:path>", websocket=True)
+@authed_only
+@bypass_csrf_protection
+def forward_sensai(path=""):
+    query_string = request.query_string.decode('utf-8')
+    full_path = f"{path}?{query_string}" if query_string else path
+    user = get_current_user()
+    user_type = "User" if not is_admin() else "Admin"
+    return redirect_internal(f"http://sensai:8080/{full_path}", auth=f"{user_type};{user.id};{user.name};{user.email};{user.password}")

--- a/dojo_theme/templates/components/navbar.html
+++ b/dojo_theme/templates/components/navbar.html
@@ -19,7 +19,7 @@
         {{ navitem("VS Code", url_for("pwncollege_workspace.view_workspace", service="vscode"), "fa-terminal", new=True) }}
         {{ navitem("桌面", url_for("pwncollege_workspace.view_workspace", service="desktop"), "fa-desktop", new=True) }}
         {{ navitem("聊天", "https://kook.top/soUkFL", "fa-comments", new=True) }}
-        {{ navitem("帮助", "https://kook.top/5ecHF2", "fa-question", new=True) }}
+        {{ navitem("帮助", url_for("pwncollege_sensai.view_sensai"), "fa-question", new=True) }}
       </ul>
 
       <hr class="d-sm-flex d-md-flex d-lg-none">

--- a/nginx-proxy/etc/nginx/vhost.d/default
+++ b/nginx-proxy/etc/nginx/vhost.d/default
@@ -18,11 +18,12 @@ location @forward {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-Prefix /sensai;
 
     proxy_set_header Authorization $redirect_auth;
 
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
+    proxy_set_header Connection "Upgrade";
     proxy_cache_bypass $http_upgrade;
 
     proxy_buffering off;


### PR DESCRIPTION
This PR adds a new "sensai" page to the project.

- **Purpose**: The "Help" button in the website's navigation bar is now linked to this "sensai" page. The page is designed to provide a frontend interaction interface for a large language model.

- **Key Changes**:
  - Added `sensai.py` under the `dojo/dojo_plugin/pages` directory. The main idea is to route requests under `/sensai` through an Nginx proxy, forwarding them to an internal service at `http://sensai:8080/`.
  - When accessing `/sensai`, `iframe.html` is configured to set the iframe source to `/sensai/`, embedding the `http://sensai:8080/` page within the iframe.
  - Added configuration for the `open-webui` container in `docker-compose`, using an image built from `https://github.com/CeS-3/sensai.git`. Modified iptables rules to allow it to connect to external networks, enabling its connection to Ollama.
  - Integrated dojo's authentication system with open-webui's authentication system for unified authentication.

- **Testing**: 
  - The frontend page has been tested on both desktop and mobile views.
  - Connection to Ollama has not yet been tested.