### PR TITLE
Fix: Add iptables rules to enable communication between Nginx and Sensai

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
 
   open-webui:
     container_name: open-webui
-    image: cees3/sensai:v2.36
+    image: cees3/sensai:v2.37
     environment:
       - OLLAMA_BASE_URLS=http://222.20.126.129:11434
     volumes:

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -92,3 +92,5 @@ iptables -I DOCKER-USER -i user_network -s 10.114.0.0/24 -m conntrack --ctstate 
 iptables -I DOCKER-USER -i user_network -d 10.114.0.0/16 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -I DOCKER-USER -i user_network -s 10.114.0.2 -j ACCEPT
 iptables -I DOCKER-USER -o user_network -d 10.114.0.2 -j ACCEPT
+iptables -I FORWARD 1 -s 10.114.0.3/32 -d 10.114.0.2/32 -p tcp --dport 8080 -j ACCEPT
+iptables -I FORWARD 1 -s 10.114.0.2/32 -d 10.114.0.3/32 -p tcp --sport 8080 -j ACCEPT


### PR DESCRIPTION
**This PR updates the dojo initialization script to ensure proper traffic flow between Nginx and open-webui containers.**

**Purpose:**  
This update is intended to address network communication issues between the Nginx container and the open-webui container by adding specific iptables rules in the dojo-init script. This change ensures that traffic can pass freely between the Nginx container (IPv4 address: 10.114.0.3) and the open-webui container (IPv4 address: 10.114.0.2).

**Key Changes:**

- **Updated dojo-init script:**  
  - Added two new iptables commands to the dojo-init script to allow traffic between the Nginx container at `10.114.0.3` and the open-webui container at `10.114.0.2`.
  - These iptables rules ensure that the Nginx container can successfully forward requests to the open-webui container without being blocked by network security settings.

**Testing:**

- **Functional Testing:**  
  - Verified that the added iptables rules allow seamless traffic between the Nginx and open-webui containers.
  - Ensured that the Nginx container can now connect to the open-webui service, allowing for proper request routing.
