### PR TITLE
Fix session deletion failure

### DIFF
--- a/dojo_plugin/pages/sensai.py
+++ b/dojo_plugin/pages/sensai.py
@@ -19,8 +19,8 @@ def view_sensai():
     return render_template("iframe.html", iframe_name="sensai", iframe_src="/sensai/", active=active)
 
 
-@sensai.route("/sensai/", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
-@sensai.route("/sensai/<path:path>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
+@sensai.route("/sensai/", methods=["GET", "POST", "DELETE", "OPTIONS"])
+@sensai.route("/sensai/<path:path>", methods=["GET", "POST", "DELETE", "OPTIONS"])
 @sensai.route("/sensai/", websocket=True)
 @sensai.route("/sensai/<path:path>", websocket=True)
 @authed_only

--- a/dojo_plugin/pages/sensai.py
+++ b/dojo_plugin/pages/sensai.py
@@ -19,8 +19,8 @@ def view_sensai():
     return render_template("iframe.html", iframe_name="sensai", iframe_src="/sensai/", active=active)
 
 
-@sensai.route("/sensai/", methods=["GET", "POST"])
-@sensai.route("/sensai/<path:path>", methods=["GET", "POST"])
+@sensai.route("/sensai/", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
+@sensai.route("/sensai/<path:path>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
 @sensai.route("/sensai/", websocket=True)
 @sensai.route("/sensai/<path:path>", websocket=True)
 @authed_only


### PR DESCRIPTION
**This PR modifies the allowed request methods for the /sensai/ route in sensai.py to enable the delete operation.**

**Purpose:**  
This update is intended to solve the problem that in the sensai service, the HTTP request method for deleting a session is 'DELETE', but only 'GET' and 'POST' methods are allowed in dojo. As a result, a 404 response is returned when attempting to perform a delete operation.

**Key Changes:**

- **The parameter list of the /sensai/ route has been modified to allow 'DELETE' requests to access the services under the /sensai/ route**  

**Testing:**

- **Functional Testing:**  
  - Verified that the added methods allow delete request to sensai service.

